### PR TITLE
Adding an example that adds an alpha ramp to the colormap.

### DIFF
--- a/examples/quadmesh.py
+++ b/examples/quadmesh.py
@@ -1,6 +1,7 @@
-# Combination of quadmesh_demo and test_axes.test_pcolormesh.
+# Modified from quadmesh_demo and test_axes.test_pcolormesh.
 
 from matplotlib import pyplot as plt
+from matplotlib.colors import ListedColormap
 import numpy as np
 
 n = 12
@@ -16,13 +17,22 @@ Z = (Z - Z.min()) / (Z.max() - Z.min())
 # The color array can include masked values:
 Zm = np.ma.masked_where(np.abs(Qz) < 0.5 * np.max(Qz), Z)
 
-fig, axs = plt.subplots(2, 2)
-axs[0, 0].pcolormesh(Qx, Qz, Z, shading='gouraud')
-axs[0, 1].pcolormesh(Qx, Qz, Zm, shading='gouraud')
-axs[1, 0].pcolormesh(Qx, Qz, Z, lw=0.5, edgecolors='k')
-axs[1, 1].pcolormesh(Qx, Qz, Z, lw=2, edgecolors=['b', 'w'])
+# Set up the colormaps
+cmap = plt.get_cmap('viridis')
+cmap_data = cmap(np.arange(cmap.N))
+# Set a linear ramp in alpha
+cmap_data[:,-1] = np.linspace(0.2, 0.8, cmap.N)
+# Create new colormap
+cmap_alpha = ListedColormap(cmap_data)
+
+fig, axs = plt.subplots(2, 2, constrained_layout=True)
+axs[0, 0].pcolormesh(Qx, Qz, Z, cmap=cmap_alpha, shading='gouraud')
+axs[0, 1].pcolormesh(Qx, Qz, Zm, cmap=cmap_alpha, shading='gouraud')
+axs[1, 0].pcolormesh(Qx, Qz, Z, cmap=cmap_alpha, edgecolors='k')
+mesh = axs[1, 1].pcolormesh(Qx, Qz, Zm, cmap=cmap_alpha)
+fig.colorbar(mesh, ax=axs[:, 1], orientation='vertical')
+
 for ax in axs.flat:
     ax.set_axis_off()
-fig.tight_layout()
 
 plt.show()


### PR DESCRIPTION
I added an example that shows the benefit of mplcairo versus the standard agg backend when handling alpha in a colormap.

The Agg backend does not handle alpha channels well at all and makes plots and colormaps look bad with edges showing up. This backend shows the expected behavior.