### PR TITLE
dpi was being set to 72 irrespective of what was supplied

### DIFF
--- a/ISSUES.rst
+++ b/ISSUES.rst
@@ -9,7 +9,9 @@ Crashes
 
 Seems to be due to cairo trying to call ``write`` during shutdown when the
 interpreter state is seriously messed up (even though ``_finish`` has been
-correctly called first).  See cairo bug #104410.
+correctly called first).  See `cairo issue #277 <cairo-277_>`_.
+
+.. _cairo-277: https://gitlab.freedesktop.org/cairo/cairo/issues/277
 
 Fix needed
 ==========

--- a/README.rst
+++ b/README.rst
@@ -72,8 +72,8 @@ As usual, install using pip:
    $ pip install mplcairo  # from PyPI
    $ pip install git+https://github.com/matplotlib/mplcairo  # from Github
 
-Note that wheels are not available for macOS, because no macOS version ships a
-recent-enough libc++ by default and vendoring of libc++ appears to be fragile.
+Note that wheels are not available for macOS<10.13, because the libc++ included
+with these versions is too old and vendoring of libc++ appears to be fragile.
 Help for packaging would be welcome.
 
 mplcairo can use Raqm_ (≥0.2) for complex text layout if it is available.
@@ -420,11 +420,12 @@ of discretized sizes, with an error bounded by the threshold.
 
 **NOTE**: ``pcolor`` and mplot3d's ``plot_surface`` display some artifacts
 where the facets join each other.  This is because these functions internally
-use a ``PathCollection``, thus triggering the approximate stamping.
-``pcolormesh`` (which internally uses a ``QuadMesh``) should generally be
-preferred over ``pcolor`` anyways. ``plot_surface`` should likewise instead
-represent the surface using ``QuadMesh``, which is drawn without such
-artefacts.
+use a ``PathCollection``; this triggers the approximate stamping, and
+even without it (by setting ``path.simplify_threshold`` to zero), cairo's
+rasterization of the edge between the facets is poor.  ``pcolormesh`` (which
+internally uses a ``QuadMesh``) should generally be preferred over ``pcolor``
+anyways.  ``plot_surface`` could likewise instead represent the surface using
+``QuadMesh``, which is drawn without such artefacts.
 
 Font formats
 ------------

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -43,8 +43,9 @@ steps:
     architecture: 'x64'
 
 - bash: |
+    set -x
 
-    pip install --upgrade pip setuptools
+    pip install --upgrade pip setuptools &&
 
     case "$(python -c 'import sys; print(sys.platform)')" in
     linux)
@@ -53,8 +54,10 @@ steps:
       sudo apt install ghostscript inkscape
       ;;
     darwin)
+      # python2 unlinking needed until brew sorts that out.
       # gs<9.50 is needed until matplotlib#15556 (matplotlib<3.2.0rc2).
       brew update >/dev/null &&
+      brew unlink python@2 &&
       brew install cairo pkg-config &&
       PKG_CONFIG_PATH=/usr/local/opt/libffi/lib/pkgconfig tools/build-macos-wheel.sh &&
       brew install https://raw.githubusercontent.com/sashkab/homebrew-core/996730866806cf0dd13a56beac47c664b1408d94/Formula/ghostscript.rb
@@ -68,7 +71,7 @@ steps:
     *)
       exit 1
       ;;
-    esac
+    esac &&
 
     python -mpip install dist/*.whl &&
     # matplotlib 3.2.0rc1 needed for tests to pass on Py3.8.

--- a/lib/mplcairo/base.py
+++ b/lib/mplcairo/base.py
@@ -242,7 +242,7 @@ class FigureCanvasCairo(FigureCanvasBase):
     def _print_method(self, renderer_factory,
                       path_or_stream, *, metadata=None, dpi=72, **kwargs):
         _check_print_extra_kwargs(**kwargs)
-        self.figure.set_dpi(72)
+        self.figure.set_dpi(dpi)
         with cbook.open_file_cm(path_or_stream, "wb") as stream:
             renderer = renderer_factory(
                 stream, self.figure.bbox.width, self.figure.bbox.height, dpi)

--- a/run-mpl-test-suite.py
+++ b/run-mpl-test-suite.py
@@ -68,7 +68,7 @@ To specify a single test module, use ``--pyargs matplotlib.tests.test_foo``.
 
     with warnings.catch_warnings():  # mpl 3.0
         warnings.filterwarnings("ignore")
-        mpl.use("agg", warn=False, force=True)
+        mpl.use("agg", force=True)
     from matplotlib import pyplot as plt
 
     __orig_switch_backend = plt.switch_backend


### PR DESCRIPTION
closes #19 (I think)

And (possibly) gets rid of "Invalid dpi manipulations in vector output." mentioned in https://github.com/matplotlib/mplcairo/blob/master/ISSUES.rst

My apologies in advance if I am trivializing the issue but this just feels like an inadvertent oversight.