### PR TITLE
Change macosx backend inheritance to FigureCanvasMac

### DIFF
--- a/lib/mplcairo/macosx.py
+++ b/lib/mplcairo/macosx.py
@@ -1,27 +1,12 @@
 import re
 
-from matplotlib.backends import _macosx
 from matplotlib.backends.backend_macosx import _BackendMac, FigureCanvasMac
 
 from . import _util
 from .base import FigureCanvasCairo
 
 
-class FigureCanvasMacCairo(FigureCanvasCairo, _macosx.FigureCanvas):
-    # Essentially: inherit from FigureCanvasMac without inheriting from
-    # FigureCanvasAgg.
-    locals().update({
-        k: v for k, v in vars(FigureCanvasMac).items()
-        if not re.fullmatch("__.*__", k)})
-
-    def __init__(self, figure):
-        # Inline the call to FigureCanvasCairo.__init__ as _macosx.FigureCanvas
-        # has a different signature and thus we cannot use cooperative
-        # inheritance (basically, we want that __init__, and only __init__,
-        # inserts FigureCanvasMac in the inheritance chain between
-        # FigureCanvasCairo and _macosx.FigureCanvasMac).
-        _util.fix_ipython_backend2gui()
-        FigureCanvasMac.__init__(self, figure)
+class FigureCanvasMacCairo(FigureCanvasCairo, FigureCanvasMac):
 
     # A bit hackish, but that's what _macosx.FigureCanvas wants...
     def _draw(self):


### PR DESCRIPTION
Fixes #23 

Changing the inheritance to FigureCanvasMac rather than _macosx.FigureCanvas seems to capture some extra event passing logic. It looks like you were trying to simulate this inheritance without having to use the FigureCanvasAgg several parents up? I'm not sure if there will be other issues with polluting the namespace or anything like that. Some simple tests on my end seemed to not show any effect, but we will see if CI has anything to say about that.