### PR TITLE
Implement support for OpenType font variations

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -33,7 +33,8 @@ Noteworthy points include:
   kerning; floating point surfaces are supported with cairo≥1.17.2).
 - Optional multithreaded drawing of markers and path collections.
 - Optional support for complex text layout (right-to-left languages, etc.) and
-  OpenType font features (see `examples/opentype_features.py`_), and partial
+  OpenType font features (see `examples/opentype_features.py`_) and variations
+  (see `examples/opentype_variations.py`_) (requires cairo≥1.16.0), and partial
   support for color fonts (e.g., emojis), using Raqm_.  **Note** that Raqm
   depends by default on Fribidi, which is licensed under the LGPLv2.1+.
 - Support for embedding URLs in PDF (but not SVG) output (requires
@@ -49,6 +50,7 @@ Noteworthy points include:
 .. _Matplotlib: http://matplotlib.org/
 .. _Raqm: https://github.com/HOST-Oman/libraqm
 .. _examples/opentype_features.py: examples/opentype_features.py
+.. _examples/opentype_variations.py: examples/opentype_variations.py
 .. _examples/operators.py: examples/operators.py
 
 Installation
@@ -105,6 +107,9 @@ path <add_dll_directory_>`_).
 
    cairo 1.15.4 added support for PDF metadata and links; the presence of this
    feature is detected at runtime.
+
+   cairo 1.16.0 added support for font variations; the presence of this feature
+   is detected at runtime.
 
    cairo 1.17.2 added support for floating point surfaces, usable with
    ``mplcairo.set_options(float_surface=True)``; the presence of this feature
@@ -456,7 +461,16 @@ language_ tag can likewise be set with ``|language=...``; currently, this
 always applies to the whole buffer, but a PR adding support for slicing syntax
 (similar to font features) would be considered.
 
+OpenType font variations can be selected by appending an additional ``|`` to
+the filename, followed by a `Cairo font variation string`_ (e.g.,
+``"/path/to/font.otf||wdth=75"``); see `examples/opentype_variations.py`_. This
+support requires Cairo>=1.16. Note that features are parsed first, so if you do
+not wish to specify any features, you must specify an empty set with two pipes,
+i.e., ``font.otf|variations`` will treat ``variations`` as features, *not*
+variations.
+
 .. _HarfBuzz feature string: https://harfbuzz.github.io/harfbuzz-hb-common.html#hb-feature-from-string
+.. _Cairo font variation string: https://www.cairographics.org/manual/cairo-cairo-font-options-t.html#cairo-font-options-set-variations
 .. _language: https://host-oman.github.io/libraqm/raqm-Raqm.html#raqm-set-language
 
 The syntaxes for selecting TTC subfonts and OpenType font features and language

--- a/examples/.gitignore
+++ b/examples/.gitignore
@@ -1,0 +1,1 @@
+Roboto Flex.ttf

--- a/examples/opentype_variations.py
+++ b/examples/opentype_variations.py
@@ -1,0 +1,84 @@
+from collections import namedtuple
+from pathlib import Path
+import string
+from urllib.parse import quote
+from urllib.request import urlretrieve
+from zipfile import ZipFile
+
+from matplotlib import font_manager as fm, gridspec, pyplot as plt
+from matplotlib.widgets import Slider
+
+
+VariableAxis = namedtuple("VariableAxis", "min max default name")
+
+DEFAULT_FONT = "Roboto Flex"
+DEFAULT_SIZE = 32
+VARIABLE_AXES = {
+    "Optical Size": VariableAxis(8, 144, DEFAULT_SIZE, "opsz"),
+    "Weight": VariableAxis(100, 1000, 400, "wght"),
+    "Width": VariableAxis(25, 151, 100, "wdth"),
+    "Slant": VariableAxis(-10, 0, 0, "slnt"),
+    "Ascender Height": VariableAxis(649, 854, 750, "YTAS"),
+    "Counter Width": VariableAxis(323, 603, 468, "XTRA"),
+    "Descender Depth": VariableAxis(-305, -98, -203, "YTDE"),
+    "Figure Height": VariableAxis(560, 788, 738, "YTFI"),
+    "Grade": VariableAxis(-200, 150, 0, "GRAD"),
+    "Lowercase Height": VariableAxis(416, 570, 514, "YTLC"),
+    "Thin Stroke": VariableAxis(25, 135, 79, "YOPQ"),
+    "Uppercase Height": VariableAxis(528, 760, 712, "YTUC"),
+}
+
+path = Path(__file__).with_name(f"{DEFAULT_FONT}.ttf")
+if not path.exists():
+    url = f"https://fonts.google.com/download?family={quote(DEFAULT_FONT)}"
+    print(f"Downloading {url} to {path}")
+    tmpfile, _ = urlretrieve(url)
+    with ZipFile(tmpfile) as zfd:
+        for member in zfd.namelist():
+            if (member.startswith(DEFAULT_FONT.replace(" ", "")) and
+                    member.endswith(".ttf")):
+                path.write_bytes(zfd.read(member))
+                break
+
+
+def generate_font(family, size, axes):
+    args = ",".join(f"{VARIABLE_AXES[title].name}={value}"
+                    for title, value in axes.items())
+    font = Path(__file__).with_name(f"{family}.ttf||{args}")
+    return fm.FontProperties(fname=font, size=size)
+
+
+fig = plt.figure(figsize=(10, 3))
+gs = gridspec.GridSpec(2, 1, figure=fig, height_ratios=[2, 1],
+                       bottom=0.05, top=1, left=0.14, right=0.95)
+
+default_font = generate_font(
+    DEFAULT_FONT, DEFAULT_SIZE,
+    {title: axis.default for title, axis in VARIABLE_AXES.items()})
+text = fig.text(
+    0.5, 2/3,
+    f"{string.ascii_uppercase}\n{string.ascii_lowercase}\n{string.digits}",
+    font=default_font,
+    horizontalalignment="center", verticalalignment="center")
+
+fig.text(0.5, 0.36, "Font Variations", horizontalalignment="center")
+option_gs = gs[1].subgridspec(6, 2, wspace=0.6)
+
+sliders = {
+    title: Slider(fig.add_subplot(ss), title,
+                  axis.min, axis.max, valstep=1, valinit=axis.default)
+    for (title, axis), ss in zip(VARIABLE_AXES.items(), option_gs)
+}
+
+
+def update_font(value):
+    fp = generate_font(
+        DEFAULT_FONT, DEFAULT_SIZE,
+        {title: slider.val for title, slider in sliders.items()})
+    text.set_font(fp)
+
+
+for slider in sliders.values():
+    slider.on_changed(update_font)
+
+plt.show()

--- a/src/_util.h
+++ b/src/_util.h
@@ -31,6 +31,8 @@ extern std::array<uint8_t, 0x10000>
 #define CAIRO_TAG_LINK "Link"
 extern void (*cairo_tag_begin)(cairo_t*, char const*, char const*);
 extern void (*cairo_tag_end)(cairo_t*, char const*);
+// Copy-pasted from cairo.h, backported from 1.16.
+extern void (*cairo_font_options_set_variations)(cairo_font_options_t *, const char *);
 
 // Modified from cairo-pdf.h.
 enum cairo_pdf_version_t {};
@@ -75,6 +77,7 @@ extern void (*cairo_svg_surface_restrict_to_version)(
 #define ITER_CAIRO_OPTIONAL_API(_) \
   _(cairo_tag_begin) \
   _(cairo_tag_end) \
+  _(cairo_font_options_set_variations) \
   _(cairo_pdf_get_versions) \
   _(cairo_pdf_surface_create_for_stream) \
   _(cairo_pdf_surface_restrict_to_version) \


### PR DESCRIPTION
This works similar to OpenType font features, in that you tack on an additional string to the path with a pipe, e.g.,
`font.ttf|feat=1|vari=2` specifies `font.ttf` with features of `feat=1` and variations of `vari=2`.

I have two questions:
1. Design-wise, does that make sense? I believe it's at least safe in that there shouldn't be any pipes in the features, but I didn't look too closely.
2. The example uses that new Mona/Hubot Sans font, but as it's large-ish, I didn't include it in the repo. That means that CI fails because the example won't run. I wonder what we should do in this case? AFAIK, DejaVu Sans does not support font variation, so we can't use that as an example.

The example copies what the announcement website does, in a Matplotlib-ish way:
[Screencast from 2022-11-10 05:07:57 AM.webm](https://user-images.githubusercontent.com/302469/201234723-d72e8083-485e-4c5d-ac50-d8b181ca848b.webm)
