### PR TITLE
FIX: Skip any nan coordinates in quadmesh

### DIFF
--- a/ext/_mplcairo.cpp
+++ b/ext/_mplcairo.cpp
@@ -1483,6 +1483,16 @@ void GraphicsContextRenderer::draw_quad_mesh(
   if (ecs_raw.shape(0)) {
     for (auto i = 0; i < mesh_height; ++i) {
       for (auto j = 0; j < mesh_width; ++j) {
+        if (!(std::isfinite(coords_raw(i, j, 0))
+              && std::isfinite(coords_raw(i, j, 1))
+              && std::isfinite(coords_raw(i, j + 1, 0))
+              && std::isfinite(coords_raw(i, j + 1, 1))
+              && std::isfinite(coords_raw(i + 1, j, 0))
+              && std::isfinite(coords_raw(i + 1, j, 1))
+              && std::isfinite(coords_raw(i + 1, j + 1, 0))
+              && std::isfinite(coords_raw(i + 1, j + 1, 1)))) {
+          continue;
+        }
         cairo_move_to(
           cr_, coords_raw(i, j, 0), coords_raw(i, j, 1));
         cairo_line_to(
@@ -1506,6 +1516,16 @@ void GraphicsContextRenderer::draw_quad_mesh(
     auto const& pattern = cairo_pattern_create_mesh();
     for (auto i = 0; i < mesh_height; ++i) {
       for (auto j = 0; j < mesh_width; ++j) {
+        if (!(std::isfinite(coords_raw(i, j, 0))
+              && std::isfinite(coords_raw(i, j, 1))
+              && std::isfinite(coords_raw(i, j + 1, 0))
+              && std::isfinite(coords_raw(i, j + 1, 1))
+              && std::isfinite(coords_raw(i + 1, j, 0))
+              && std::isfinite(coords_raw(i + 1, j, 1))
+              && std::isfinite(coords_raw(i + 1, j + 1, 0))
+              && std::isfinite(coords_raw(i + 1, j + 1, 1)))) {
+          continue;
+        }
         cairo_mesh_pattern_begin_patch(pattern);
         cairo_mesh_pattern_move_to(
           pattern, coords_raw(i, j, 0), coords_raw(i, j, 1));


### PR DESCRIPTION
Even though the coordinates of quadmesh are meant to be finite, a transform may make them nonfinite. This adds a check to avoid the nan quads in the quadmesh rendering routine.

This fixes an issue in Cartopy+mplcairo
xref: https://github.com/SciTools/cartopy/issues/2305

> It would be nice if the backend spec (essentially the docstrings of the base methods in RendererBase) specified clearly which methods need to support nans, and for which inputs.

I agree, and perhaps even try to add some tests on that assertion, not just docstrings if we could. Do you want me to try and implement a test here, or look into adding something upstream in matplotlib?